### PR TITLE
add registries for github/gitlab raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ udd supports the following registry domains:
 - https://dev.jspm.io
 - https://cdn.pika.dev
 - https://unpkg.com
+- https://raw.githubusercontent.com
+- https://gitlab.com/:user/:repo/-/raw
 
 _Create an issue to request additional registries._
 


### PR DESCRIPTION
Add support for GitHub and GitLab URLs.

E.g.
``` typescript
import thing from "https://raw.githubusercontent.com/user/repo/v2.4.0/thing.ts"
import stuff from "https://gitlab.com/user/repo/-/raw/v3.7.2/stuff.ts"
```

### Changes
- created `GithubRaw` and `GitlabRaw` and added them to `REGISTRIES`