### PR TITLE
Remove all uses of `any` type

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -2,7 +2,7 @@ import { decode, encode, colors } from "./deps.ts";
 import { Progress, SilentProgress } from "./progress.ts";
 import { importUrls } from "./search.ts";
 import { Semver, fragment, semver } from "./semver.ts";
-import { REGISTRIES, RegistryUrl, lookup } from "./registry.ts";
+import { REGISTRIES, RegistryCtor, RegistryUrl, lookup } from "./registry.ts";
 
 // FIXME we should catch ctrl-c etc. and write back the original deps.ts
 
@@ -22,7 +22,7 @@ export interface UddOptions {
   // if this function errors then the update is reverted
   test?: () => Promise<void>;
 
-  _registries?: any[];
+  _registries?: RegistryCtor[];
 }
 
 export interface UddResult {
@@ -37,7 +37,7 @@ export class Udd {
   private test: () => Promise<void>;
   private options: UddOptions;
   private progress: Progress;
-  private registries: any[];
+  private registries: RegistryCtor[];
 
   constructor(
     filename: string,

--- a/registry.ts
+++ b/registry.ts
@@ -1,4 +1,4 @@
-type RegistryCtor = new (url: string) => RegistryUrl;
+export type RegistryCtor = new (url: string) => RegistryUrl;
 export function lookup(url: string, registries: RegistryCtor[]):
   | RegistryUrl
   | undefined {
@@ -89,7 +89,12 @@ async function githubReleases(
   return versions;
 }
 
-let denoLandDB: any;
+interface DenoLandDBEntry {
+  type: string;
+  owner: string;
+  repo: string;
+}
+let denoLandDB: Record<string, DenoLandDBEntry>;
 
 export class DenoLand implements RegistryUrl {
   url: string;
@@ -108,7 +113,7 @@ export class DenoLand implements RegistryUrl {
         "https://raw.githubusercontent.com/denoland/deno_website2/master/database.json";
       denoLandDB = await (await fetch(dbUrl)).json();
     }
-    let res: any;
+    let res: DenoLandDBEntry;
     try {
       res = denoLandDB[this.name()];
     } catch {

--- a/search.ts
+++ b/search.ts
@@ -1,4 +1,4 @@
-import { RegistryUrl } from "./registry.ts";
+import { RegistryCtor } from "./registry.ts";
 
 // FIXME use deno info once it has json output?
 
@@ -7,7 +7,7 @@ import { RegistryUrl } from "./registry.ts";
 // import "https?://deno.land/(std|x)@([^/"]?)/.*?"
 // import { foo, bar } from "https?://deno.land/(std|x)@([^/"]?)/.*?"
 
-export function importUrls(tsContent: string, registries: any[]): string[] {
+export function importUrls(tsContent: string, registries: RegistryCtor[]): string[] {
   // look up all the supported regex matches.
   const rs: RegExp[] = registries.map((R) => new R("").regexp).map((re) =>
     new RegExp(re, "g")

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,6 @@
 import { udd, UddOptions, UddResult } from "./mod.ts";
 import { decode, encode } from "./deps.ts";
+import { RegistryCtor } from './registry.ts'
 import {
   FakeRegistry,
   FakeDenoStd,
@@ -11,7 +12,7 @@ import {
 async function testUdd(
   before: string,
   after: string,
-  registries: any[] = [FakeRegistry],
+  registries: RegistryCtor[] = [FakeRegistry],
 ) {
   const fn = await Deno.makeTempFile();
   try {


### PR DESCRIPTION
As per https://github.com/hayd/deno-udd/pull/14#issuecomment-645190366, fix `deno lint` by removing all uses of `any`.

@hayd 