### PR TITLE
Support branch names

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -92,6 +92,14 @@ export class Udd {
       url.url = `${url.at(initVersion.slice(1)).url}#${newFragmentToken}`;
     }
 
+    try {
+      new Semver(url.version());
+    } catch (e) {
+      // probably, the version string is a branch name.
+      await this.progress.log(`Using a branch: ${url.url}`);
+      return { initUrl, initVersion };
+    }
+
     // if we pass a fragment with semver
     let filter: ((other: Semver) => boolean) | undefined = undefined;
     try {

--- a/mod.ts
+++ b/mod.ts
@@ -95,8 +95,8 @@ export class Udd {
     try {
       new Semver(url.version());
     } catch (e) {
-      // probably, the version string is a branch name.
-      await this.progress.log(`Using a branch: ${url.url}`);
+      // The version string is a non-semver string like a branch name.
+      await this.progress.log(`Skip updating: ${url.url}`);
       return { initUrl, initVersion };
     }
 

--- a/test.ts
+++ b/test.ts
@@ -151,3 +151,16 @@ Deno.test("uddFakeregistryFragmentMoveEq", async () => {
   const expected = 'import "https://fakeregistry.com/foo@0.0.1/mod.ts#=";';
   await testUdd(contents, expected);
 });
+
+Deno.test("uddGitHubRawBranchName", async () => {
+  const contents = `
+import "https://raw.githubusercontent.com/foo/bar/main/mod.ts";
+import "https://raw.githubusercontent.com/foo/bar/main/mod.ts#=";
+`;
+  const expected = `
+import "https://raw.githubusercontent.com/foo/bar/main/mod.ts";
+import "https://raw.githubusercontent.com/foo/bar/main/mod.ts#=";
+`;
+  const results = await testUdd(contents, expected);
+  assertEquals(results.length, 0);
+});


### PR DESCRIPTION
Currently, udd updates the following module with the latest tag:

```ts
// main -> 5.5.1
export { default as puppeteer } from 'https://raw.githubusercontent.com/masnagam/deno-puppeteer/main/mod.ts';
```

However, banch-specific modules should not be updated in many cases.

This PR skips updating if `url.version()` is not a semver (probably, it's a branch name).