### PR TITLE
fixed npm regexp

### DIFF
--- a/registry.ts
+++ b/registry.ts
@@ -198,7 +198,7 @@ export class Npm implements RegistryUrl {
     return version;
   }
 
-  regexp = /npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^/]+))?[^\'\"]/;
+  regexp = /npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^\/\"\']+))?[^\'\"]/;
 }
 
 async function unpkgVersions(name: string): Promise<string[]> {


### PR DESCRIPTION
I have this script:

```ts
export * as preact from "npm:preact@10.11.2";
export * as hooks from "npm:preact@10.11.2/hooks";
```
And the regular expresion of NPM registry captures this:
`npm:preact@10.11.2";\nexport * as hooks from "npm:preact@10.11.2/`

so the package is never updated. This change fixes it.