### PR TITLE
Parse modifiers in versions

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,11 @@
 import { udd, UddOptions, UddResult } from "./mod.ts";
 import { RegistryCtor } from "./registry.ts";
-import { assertEquals, FakeDenoLand, FakeRegistry } from "./test_deps.ts";
+import {
+  assertEquals,
+  FakeDenoLand,
+  FakeNpm,
+  FakeRegistry,
+} from "./test_deps.ts";
 
 async function testUdd(
   before: string,
@@ -158,4 +163,14 @@ import "https://raw.githubusercontent.com/foo/bar/main/mod.ts#=";
 `;
   const results = await testUdd(contents, expected);
   assertEquals(results.length, 0);
+});
+
+Deno.test("uddNpmWithTilde", async () => {
+  const contents = `
+import Fuse from "npm:fuse.js@~6.6.0"
+`;
+  const expected = `
+import Fuse from "npm:fuse.js@6.6.6"
+`;
+  await testUdd(contents, expected, [FakeNpm]);
 });

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,4 +1,4 @@
-import { defaultAt, defaultVersion, RegistryUrl } from "./registry.ts";
+import { defaultAt, defaultVersion, Npm, RegistryUrl } from "./registry.ts";
 import { DenoLand } from "./registry.ts";
 
 export {
@@ -40,39 +40,8 @@ export class FakeDenoLand extends DenoLand {
   }
 }
 
-export class FakeNpm extends RegistryUrl {
-  url: string;
-  parseRegex = /^npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^/]+))?(.*)/;
-
-  constructor(url: string) {
-    super();
-    this.url = url;
-  }
-
-  name(): string {
-    const [, name] = this.url.match(this.parseRegex)!;
-
-    return name;
-  }
-
-  at(version: string): RegistryUrl {
-    const [, name, _, files] = this.url.match(this.parseRegex)!;
-    const url = `npm:${name}@${version}${files}`;
-    return new FakeNpm(url);
-  }
-
-  versionInner(): string {
-    const [, _, version] = this.url.match(this.parseRegex)!;
-    if (version === null) {
-      throw Error(`Unable to find version in ${this.url}`);
-    }
-    return version;
-  }
-
-  regexp = /npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^\/\"\']+))?[^\'\"]/;
-
-  // deno-lint-ignore require-await
+export class FakeNpm extends Npm {
   async all(): Promise<string[]> {
-    return ["6.6.6", "6.7.0", "7.0.0"];
+    return await Promise.resolve(["6.6.6", "6.7.0", "7.0.0"]);
   }
 }

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -8,10 +8,11 @@ export {
   assertThrowsAsync,
 } from "https://deno.land/std@0.80.0/testing/asserts.ts";
 
-export class FakeRegistry implements RegistryUrl {
+export class FakeRegistry extends RegistryUrl {
   url: string;
 
   constructor(url: string) {
+    super();
     this.url = url;
   }
 
@@ -36,5 +37,42 @@ export class FakeDenoLand extends DenoLand {
   // deno-lint-ignore require-await
   async all(): Promise<string[]> {
     return ["0.35.0", "0.34.0"];
+  }
+}
+
+export class FakeNpm extends RegistryUrl {
+  url: string;
+  parseRegex = /^npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^/]+))?(.*)/;
+
+  constructor(url: string) {
+    super();
+    this.url = url;
+  }
+
+  name(): string {
+    const [, name] = this.url.match(this.parseRegex)!;
+
+    return name;
+  }
+
+  at(version: string): RegistryUrl {
+    const [, name, _, files] = this.url.match(this.parseRegex)!;
+    const url = `npm:${name}@${version}${files}`;
+    return new FakeNpm(url);
+  }
+
+  versionInner(): string {
+    const [, _, version] = this.url.match(this.parseRegex)!;
+    if (version === null) {
+      throw Error(`Unable to find version in ${this.url}`);
+    }
+    return version;
+  }
+
+  regexp = /npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^\/\"\']+))?[^\'\"]/;
+
+  // deno-lint-ignore require-await
+  async all(): Promise<string[]> {
+    return ["6.6.6", "6.7.0", "7.0.0"];
   }
 }


### PR DESCRIPTION
Fix https://github.com/hayd/deno-udd/issues/96

I personally would expect that `~6.6.0` becomes `~6.6.6` (tilde) remain, but I saw that there are tests in the codebase that expect the modifier stripped.