### PR TITLE
fix: npm registry with deno update syntax

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -87,12 +87,12 @@ export class Udd {
     let newVersion = versions[0];
 
     // FIXME warn that the version modifier is moved to a fragment...
-    // if the version includes a modifier we move it to the fragment
-    if (initVersion[0].match(/^[\~\^\=\<]/) && !url.url.includes("#")) {
+    // if the version includes a modifier we move it to the fragment    
+    if (initVersion[0].match(/^[\~\^\=\<]/) && !url.url.includes("#")) {      
       newFragmentToken = initVersion[0];
       url.url = `${url.at(initVersion.slice(1)).url}#${newFragmentToken}`;
-    }
-
+    }  
+    
     try {
       new Semver(url.version());
     } catch (_) {
@@ -132,6 +132,11 @@ export class Udd {
         };
       }
       newVersion = compatible[0];
+    }
+
+    // Put the version token back where it was at the prefix since we moved it to fragment 
+    if (newFragmentToken != undefined) {
+      newVersion = `${newFragmentToken}${newVersion}`
     }
 
     if (url.version() === newVersion && newFragmentToken === undefined) {

--- a/registry.ts
+++ b/registry.ts
@@ -148,7 +148,7 @@ export class DenoLand implements RegistryUrl {
 const NPM_CACHE: Map<string, string[]> = new Map<string, string[]>();
 export class Npm implements RegistryUrl {
   url: string;
-  parseRegex = /^npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^#/]+))?(.*)/;
+  parseRegex = /^npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^/]+))?(.*)/;
 
   constructor(url: string) {
     this.url = url;
@@ -191,7 +191,8 @@ export class Npm implements RegistryUrl {
   }
 
   version(): string {
-    const [, _, version] = this.url.match(this.parseRegex)!;
+    const [, _, versionWithFragmentSuffix] = this.url.match(this.parseRegex)!;
+    const [, version] = versionWithFragmentSuffix.match(/([^#]+)/)! // remove fragment #~ suffix if it exists. 
     if (version === null) {
       throw Error(`Unable to find version in ${this.url}`);
     }

--- a/registry.ts
+++ b/registry.ts
@@ -148,7 +148,7 @@ export class DenoLand implements RegistryUrl {
 const NPM_CACHE: Map<string, string[]> = new Map<string, string[]>();
 export class Npm implements RegistryUrl {
   url: string;
-  parseRegex = /^npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^/]+))?(.*)/;
+  parseRegex = /^npm:(\@[^/]+\/[^@/]+|[^@/]+)(?:\@([^#/]+))?(.*)/;
 
   constructor(url: string) {
     this.url = url;

--- a/registry_test.ts
+++ b/registry_test.ts
@@ -181,11 +181,13 @@ Deno.test("registryNpm", () => {
 });
 
 Deno.test("registryNpmUpgradeFragment", () => {
-  const url = "npm:@octokit/rest@19.0.0#~";
+  const url = "npm:foo@0.1.0#~";
   const v = lookup(url, REGISTRIES);
   assert(v !== undefined);
 
-  assertEquals(v.version(), "19.0.0");
+  assertEquals(v.version(), "0.1.0");
+  const vAt = v.at("0.2.0");
+  assertEquals(vAt.url, "npm:foo@0.2.0");  
 });
 
 Deno.test("registryNpmOrg", () => {

--- a/registry_test.ts
+++ b/registry_test.ts
@@ -180,6 +180,14 @@ Deno.test("registryNpm", () => {
   assertEquals(vAt.url, "npm:foo@0.2.0/foo");
 });
 
+Deno.test("registryNpmUpgradeFragment", () => {
+  const url = "npm:@octokit/rest@19.0.0#~";
+  const v = lookup(url, REGISTRIES);
+  assert(v !== undefined);
+
+  assertEquals(v.version(), "19.0.0");
+});
+
 Deno.test("registryNpmOrg", () => {
   const url = "npm:@foo/foo@0.1.0/foo";
   const v = lookup(url, REGISTRIES);


### PR DESCRIPTION
Fixes: https://github.com/hayd/deno-udd/issues/96

udd takes a npm import `npm:ical-generator@^4.0.0` and converts that to `npm:ical-generator@4.0.0#^` [from this line of code](https://github.com/hayd/deno-udd/blob/09f9994e2588a0744b8983f91122932b494eb176/mod.ts#L91-L94)

The npm regex gives you the version string of `4.0.0#^` which [`SemVer()`](https://github.com/hayd/deno-udd/blob/09f9994e2588a0744b8983f91122932b494eb176/mod.ts#L97) fails at. 

This PR fixes the problem by getting the version from `npm:ical-generator@4.0.0#^` to return `4.0.0` instead of `4.0.0#^`. 

