### PR TITLE
fix #113

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,4 @@
 export { parse as parseArgs } from "https://deno.land/std@0.166.0/flags/mod.ts";
 export { expandGlob } from "https://deno.land/std@0.166.0/fs/mod.ts";
 export * as colors from "https://deno.land/std@0.166.0/fmt/colors.ts";
+export type { Writer } from "https://deno.land/std@0.212.0/io/types.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { parse as parseArgs } from "https://deno.land/std@0.166.0/flags/mod.ts";
+export { parseArgs } from "https://deno.land/std@0.207.0/cli/mod.ts";
 export { expandGlob } from "https://deno.land/std@0.166.0/fs/mod.ts";
 export * as colors from "https://deno.land/std@0.166.0/fmt/colors.ts";
 export type { Writer } from "https://deno.land/std@0.212.0/io/types.ts";

--- a/progress.ts
+++ b/progress.ts
@@ -1,3 +1,5 @@
+import { Writer } from "./deps.ts";
+
 const { noColor } = Deno;
 
 const START = noColor ? "" : "\x1b[999D\x1b[K";
@@ -8,9 +10,9 @@ const encoder = new TextEncoder();
 export class Progress {
   n: number;
   step = -1;
-  writer: Deno.Writer;
+  writer: Writer;
 
-  constructor(n: number, writer: Deno.Writer = Deno.stdout) {
+  constructor(n: number, writer: Writer = Deno.stdout) {
     this.n = n;
     this.writer = writer;
   }

--- a/progress.ts
+++ b/progress.ts
@@ -25,5 +25,5 @@ export class Progress {
 }
 
 export class SilentProgress extends Progress {
-  async log(_: string) {}
+  override async log(_: string) {}
 }

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -5,8 +5,7 @@ export {
   assert,
   assertEquals,
   assertThrows,
-  assertThrowsAsync,
-} from "https://deno.land/std@0.80.0/testing/asserts.ts";
+} from "https://deno.land/std@0.196.0/assert/mod.ts";
 
 export class FakeRegistry implements RegistryUrl {
   url: string;

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -34,7 +34,7 @@ export class FakeRegistry implements RegistryUrl {
 
 export class FakeDenoLand extends DenoLand {
   // deno-lint-ignore require-await
-  async all(): Promise<string[]> {
+  override async all(): Promise<string[]> {
     return ["0.35.0", "0.34.0"];
   }
 }


### PR DESCRIPTION
fix #113

- fix: replace Deno.run with Deno.Command
  > `Deno.run` was removed in Deno 2. See the Deno 1.x to 2.x Migration Guide for further details: https://docs.deno.com/runtime/reference/migrate_deprecations/

  Deno.run is deprecated since [v1.31](https://deno.com/blog/v1.31#api-stabilizations)
- fix: replace Deno.Writer with Writer from the standard library  
  Deno.Write is deprecated since [v1.39](https://deno.com/blog/v1.39#deprecated-io-interfaces)  
  https://docs.deno.com/runtime/reference/migration_guide/#api-changes 
- fix(TS4114): add missing override modifier
